### PR TITLE
FEAT 5460: Make DataFrameGroupBy.value counts more distributed 

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -137,6 +137,24 @@ class DataFrameGroupBy(ClassLogger):
             numeric_only=True,
         )
 
+    def value_counts(
+        self,
+        subset=None,
+        normalize: bool = False,
+        sort: bool = True,
+        ascending: bool = False,
+        dropna: bool = True,
+    ):
+        return self._default_to_pandas(
+            lambda df: df.value_counts(
+                subset=subset,
+                normalize=normalize,
+                sort=sort,
+                ascending=ascending,
+                dropna=dropna,
+            )
+        )
+
     def mean(self, numeric_only=None):
         return self._check_index(
             self._wrap_aggregation(
@@ -1306,6 +1324,24 @@ class SeriesGroupBy(DataFrameGroupBy):
                 )
                 for k in (sorted(group_ids) if self._sort else group_ids)
             )
+
+    def value_counts(
+        self,
+        normalize: bool = False,
+        sort: bool = True,
+        ascending: bool = False,
+        bins=None,
+        dropna: bool = True,
+    ):
+        return self._default_to_pandas(
+            lambda ser: ser.value_counts(
+                normalize=normalize,
+                sort=sort,
+                ascending=ascending,
+                bins=bins,
+                dropna=dropna,
+            )
+        )
 
     def unique(self):
         return self._check_index(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -144,25 +144,22 @@ class DataFrameGroupBy(ClassLogger):
         sort: bool = True,
         ascending: bool = False,
         dropna: bool = True):
-        # dfGroupBy.value_counts is semantically
+        # dfGroupBy.value_counts nearly semantically
         # equivalent to df.value_counts([<by>, <other...>]).sort_index()
         # it returns a MultiIndex Series which needs to be converted to
-        # pandas for sort_index
-        print("BY: ",self._by, " COLS: ", self._columns.values)
+        # pandas for sort_index.
         if is_list_like(self._by):
             subset = self._by
         elif isinstance(self._by, type(self._query_compiler)):
             subset = self._by.columns.values.tolist()
-        #print(">>> BY: ",mine, " type ", type(mine) ,"COLS: ", allof, " type: ", type(allof))
         for c in self._columns.values.tolist():
             if c not in subset:
                 subset.append(c)
-        print("  SUBSET", subset)
         return self._df.value_counts(subset=subset, 
             normalize=normalize, 
             sort=sort, 
             ascending=ascending, 
-            dropna=dropna)._to_pandas().sort_index()
+            dropna=dropna)._to_pandas().sort_index(level=0, sort_remaining=False)
 
     def mean(self, numeric_only=None):
         return self._check_index(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -150,15 +150,14 @@ class DataFrameGroupBy(ClassLogger):
         # pandas for sort_index
         print("BY: ",self._by, " COLS: ", self._columns.values)
         if is_list_like(self._by):
-            mine = self._by
-            allof = self._columns.values
-            print(">>> BY: ",mine, " COLS: ", allof)
-            subset = mine.extend(allof)
-            print("  SUBSET", subset)
-
+            subset = self._by
         elif isinstance(self._by, type(self._query_compiler)):
-            subset = self._by.columns.values
-
+            subset = self._by.columns.values.tolist()
+        #print(">>> BY: ",mine, " type ", type(mine) ,"COLS: ", allof, " type: ", type(allof))
+        for c in self._columns.values.tolist():
+            if c not in subset:
+                subset.append(c)
+        print("  SUBSET", subset)
         return self._df.value_counts(subset=subset, 
             normalize=normalize, 
             sort=sort, 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -128,7 +128,7 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def ffill(self, limit=None):
-        return self.fillna(limit=limit, method='ffill')
+        return self.fillna(limit=limit, method="ffill")
 
     def sem(self, ddof=1):
         return self._wrap_aggregation(
@@ -143,7 +143,8 @@ class DataFrameGroupBy(ClassLogger):
         normalize: bool = False,
         sort: bool = True,
         ascending: bool = False,
-        dropna: bool = True):
+        dropna: bool = True,
+    ):
         # dfGroupBy.value_counts nearly semantically
         # equivalent to df.value_counts([<by>, <other...>]).sort_index()
         # it returns a MultiIndex Series which needs to be converted to
@@ -155,11 +156,17 @@ class DataFrameGroupBy(ClassLogger):
         for c in self._columns.values.tolist():
             if c not in subset:
                 subset.append(c)
-        return self._df.value_counts(subset=subset, 
-            normalize=normalize, 
-            sort=sort, 
-            ascending=ascending, 
-            dropna=dropna)._to_pandas().sort_index(level=0, sort_remaining=False)
+        return (
+            self._df.value_counts(
+                subset=subset,
+                normalize=normalize,
+                sort=sort,
+                ascending=ascending,
+                dropna=dropna,
+            )
+            ._to_pandas()
+            .sort_index(level=0, sort_remaining=False)
+        )
 
     def mean(self, numeric_only=None):
         return self._check_index(
@@ -513,7 +520,7 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def bfill(self, limit=None):
-        return self.fillna(limit=limit, method='bfill')
+        return self.fillna(limit=limit, method="bfill")
 
     def idxmin(self):
         return self._default_to_pandas(lambda df: df.idxmin())
@@ -674,7 +681,7 @@ class DataFrameGroupBy(ClassLogger):
         return self._default_to_pandas(lambda df: df.corrwith)
 
     def pad(self, limit=None):
-        return self.fillna(limit=limit, method='pad')
+        return self.fillna(limit=limit, method="pad")
 
     def max(self, numeric_only=False, min_count=-1):
         return self._wrap_aggregation(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -145,16 +145,18 @@ class DataFrameGroupBy(ClassLogger):
         ascending: bool = False,
         dropna: bool = True,
     ):
+        # Compatibility Notes:
         # dfGroupBy.value_counts nearly semantically
         # equivalent to df.value_counts([<by>, <other...>]).sort_index()
         # it returns a MultiIndex Series which needs to be converted to
         # pandas for sort_index.
         # 
+        # Semantic Exceptions:
         # normalize does not work; it will return the normalized results
-        #     across the entire dataframe, not within the smallest level
+        #     across the entire dataframe, not within the sub levels
         # DataFrame(as_index=False) does not work. The default is True
-        #     calling this function will result in a Series rather than
-        #     a DataFrame
+        #     calling this function will always result in a Series rather 
+        #     than a DataFrame
         #
         if is_list_like(self._by):
             subset = self._by

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -145,6 +145,20 @@ class DataFrameGroupBy(ClassLogger):
         ascending: bool = False,
         dropna: bool = True,
     ):
+        # Normalization needs to take place on
+        # the DataFrameGroupBy object itself
+        # and cannot be pushed down
+        if normalize or self._as_index == False:
+            return self._default_to_pandas(
+                lambda df: df.value_counts(
+                    subset=subset,
+                    normalize=normalize,
+                    sort=sort,
+                    ascending=ascending,
+                    dropna=dropna,
+                )
+        )
+        
         # dfGroupBy.value_counts nearly semantically
         # equivalent to df.value_counts([<by>, <other...>]).sort_index()
         # it returns a MultiIndex Series which needs to be converted to
@@ -159,7 +173,7 @@ class DataFrameGroupBy(ClassLogger):
         return (
             self._df.value_counts(
                 subset=subset,
-                normalize=normalize,
+                normalize=False,
                 sort=sort,
                 ascending=ascending,
                 dropna=dropna,

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -198,6 +198,7 @@ def test_mixed_dtypes_groupby(as_index):
         eval_sum(modin_groupby, pandas_groupby)
         eval_ngroup(modin_groupby, pandas_groupby)
         eval_nunique(modin_groupby, pandas_groupby)
+        eval_value_counts(modin_groupby, pandas_groupby)
         eval_median(modin_groupby, pandas_groupby)
         eval_general(modin_groupby, pandas_groupby, lambda df: df.head(n))
         eval_cumprod(modin_groupby, pandas_groupby)
@@ -591,6 +592,7 @@ def test_single_group_row_groupby():
     eval_sum(modin_groupby, pandas_groupby)
     eval_ngroup(modin_groupby, pandas_groupby)
     eval_nunique(modin_groupby, pandas_groupby)
+    eval_value_counts(modin_groupby, pandas_groupby)
     eval_median(modin_groupby, pandas_groupby)
     eval_general(modin_groupby, pandas_groupby, lambda df: df.head(n))
     eval_cumprod(modin_groupby, pandas_groupby)
@@ -709,6 +711,7 @@ def test_large_row_groupby(is_by_category):
     eval_sum(modin_groupby, pandas_groupby)
     eval_ngroup(modin_groupby, pandas_groupby)
     eval_nunique(modin_groupby, pandas_groupby)
+    eval_value_counts(modin_groupby, pandas_groupby)
     eval_median(modin_groupby, pandas_groupby)
     eval_general(modin_groupby, pandas_groupby, lambda df: df.head(n))
     # eval_cumprod(modin_groupby, pandas_groupby) causes overflows
@@ -816,6 +819,8 @@ def test_simple_col_groupby():
     # Pandas fails on this case with ValueError
     # eval_ngroup(modin_groupby, pandas_groupby)
     # eval_nunique(modin_groupby, pandas_groupby)
+    # NotImplementedError: DataFrameGroupBy.value_counts only handles axis=0
+    # eval_value_counts(modin_groupby, pandas_groupby)
     eval_median(modin_groupby, pandas_groupby)
     eval_general(
         modin_groupby,
@@ -942,6 +947,7 @@ def test_series_groupby(by, as_index_series_or_dataframe):
         eval_size(modin_groupby, pandas_groupby)
         eval_ngroup(modin_groupby, pandas_groupby)
         eval_nunique(modin_groupby, pandas_groupby)
+        eval_value_counts(modin_groupby, pandas_groupby)
         eval_median(modin_groupby, pandas_groupby)
         eval_general(modin_groupby, pandas_groupby, lambda df: df.head(n))
         eval_cumprod(modin_groupby, pandas_groupby)
@@ -1074,6 +1080,10 @@ def eval_ngroup(modin_groupby, pandas_groupby):
 
 def eval_nunique(modin_groupby, pandas_groupby):
     df_equals(modin_groupby.nunique(), pandas_groupby.nunique())
+
+
+def eval_value_counts(modin_groupby, pandas_groupby):
+    df_equals(modin_groupby.value_counts(), pandas_groupby.value_counts())
 
 
 def eval_median(modin_groupby, pandas_groupby):


### PR DESCRIPTION
The current implementation of dfgroupby.value_counts immediately defaults to pandas. This version will emulate this behavior by performing the value counts on the underlying data frame with the unique set of columns.

| Object | call | Pushdown? | Compatibility |
| --- | --- | --- | --- |
| DataFrameGroupBy | value_counts() | Full | PASS |
| DataFrameGroupBy | value_counts(ascending=True) |Full | PASS |
| DataFrameGroupBy | value_counts(ascending=False) | Full |PASS |
| DataFrameGroupBy | value_counts(sort=False) |Full | PASS |
| DataFrameGroupBy | value_counts(sort=True) |Full | PASS |
| DataFrameGroupBy | value_counts(normalize=False) |Full | PASS |
| DataFrameGroupBy | value_counts(normalize=True) | | FAIL |
| DataFrame | groupby(as_index=False) |  | FAIL |
| DataFrameGroupBy | value_counts(dropna=False) | Full  | PASS
| DataFrameGroupBy | value_counts(dropna=True) |  |FAIL

