### PR TITLE
FIX: Reset axes correctly for NumPy [no upstream]

### DIFF
--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -180,14 +180,17 @@ class array(object):
 
             self._query_compiler = pd.DataFrame(arr)._query_compiler
             new_dtype = arr.dtype
-        if StorageFormat.get() == "Pandas":
-            # These two lines are necessary so that our query compiler does not keep track of indices
-            # and try to map like indices to like indices. (e.g. if we multiply two arrays that used
-            # to be dataframes, and the dataframes had the same column names but ordered differently
-            # we want to do a simple broadcast where we only consider position, as numpy would, rather
-            # than pair columns with the same name and multiply them.)
-            self._query_compiler = self._query_compiler.reset_index(drop=True)
-            self._query_compiler.columns = range(len(self._query_compiler.columns))
+        # These two lines are necessary so that our query compiler does not keep track of indices
+        # and try to map like indices to like indices. (e.g. if we multiply two arrays that used
+        # to be dataframes, and the dataframes had the same column names but ordered differently
+        # we want to do a simple broadcast where we only consider position, as numpy would, rather
+        # than pair columns with the same name and multiply them.)
+        self._query_compiler = self._query_compiler.reset_index(drop=True)
+        desired_columns = pandas.Index(
+            [str(pos) for pos in range(len(self._query_compiler.columns))]
+        )
+        if not self._query_compiler.columns.equals(desired_columns):
+            self._query_compiler.columns = desired_columns
         new_dtype = new_dtype if dtype is None else dtype
         cols_with_wrong_dtype = self._query_compiler.dtypes != new_dtype
         if cols_with_wrong_dtype.any():

--- a/modin/numpy/indexing.py
+++ b/modin/numpy/indexing.py
@@ -318,6 +318,8 @@ class ArrayIndexer(object):
                 _ndim = 2
             else:
                 _ndim = 1
+                if row_scalar:
+                    qc_view = qc_view.transpose()
 
         if _ndim == 0:
             return qc_view.to_numpy()[0, 0]

--- a/modin/numpy/indexing.py
+++ b/modin/numpy/indexing.py
@@ -318,8 +318,6 @@ class ArrayIndexer(object):
                 _ndim = 2
             else:
                 _ndim = 1
-                if row_scalar:
-                    qc_view = qc_view.transpose()
 
         if _ndim == 0:
             return qc_view.to_numpy()[0, 0]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
