### PR TITLE
FEAT: Add partial support for `df.unstack()` [do not upstream]

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2024,7 +2024,7 @@ class DataFrame(BasePandasDataset):
         """
         Stack the prescribed level(s) from columns to index.
         """
-        is_multiindex = len(self.index.names) > 1
+        is_multiindex = isinstance(self.columns, pandas.MultiIndex)
         if not is_multiindex or (
             is_multiindex and is_list_like(level) and len(level) == self.columns.nlevels
         ):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1500,10 +1500,10 @@ class DataFrame(BasePandasDataset):
         """
         Pivot a level of the (necessarily hierarchical) index labels.
         """
-        if not isinstance(self.index, pandas.MultiIndex) or (
-            isinstance(self.index, pandas.MultiIndex)
-            and is_list_like(level)
-            and len(level) == self.index.nlevels
+        # Hack since we can't check the class type
+        is_multiindex = len(self.index.names) > 1
+        if not is_multiindex or (
+            is_multiindex and is_list_like(level) and len(level) == self.index.nlevels
         ):
             return self._reduce_dimension(
                 query_compiler=self._query_compiler.unstack(level, fill_value)
@@ -2020,10 +2020,9 @@ class DataFrame(BasePandasDataset):
         """
         Stack the prescribed level(s) from columns to index.
         """
-        if not isinstance(self.columns, pandas.MultiIndex) or (
-            isinstance(self.columns, pandas.MultiIndex)
-            and is_list_like(level)
-            and len(level) == self.columns.nlevels
+        is_multiindex = len(self.index.names) > 1
+        if not is_multiindex or (
+            is_multiindex and is_list_like(level) and len(level) == self.columns.nlevels
         ):
             return self._reduce_dimension(
                 query_compiler=self._query_compiler.stack(level, dropna)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1517,6 +1517,10 @@ class DataFrame(BasePandasDataset):
         """
         Return reshaped ``DataFrame`` organized by given index / column values.
         """
+        # if values is not specified, it should be the remaining columns not in
+        # index or columns
+        if values is None:
+            values = [c for c in self.columns if c not in index and c not in columns]
         return self.__constructor__(
             query_compiler=self._query_compiler.pivot(
                 index=index, columns=columns, values=values

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1392,9 +1392,14 @@ class Series(BasePandasDataset):
         """
         from .dataframe import DataFrame
 
-        result = DataFrame(
-            query_compiler=self._query_compiler.unstack(level, fill_value)
-        )
+        # This feels a little hacky, but I don't think it's possible to have a
+        # MultiIndex with just one column.
+        if len(self.index.names) > 1:
+            result = DataFrame(
+                query_compiler=self._query_compiler.unstack(level, fill_value)
+            )
+        else:
+            raise ValueError(f"index must be a MultiIndex to unstack")
 
         return result.droplevel(0, axis=1) if result.columns.nlevels > 1 else result
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2224,7 +2224,6 @@ def test_loc(data):
     data = np.arange(100)
     modin_series = pd.Series(data, index=index).sort_index()
     pandas_series = pandas.Series(data, index=index).sort_index()
-    # Using 'fmt: skip' below as 'black' and 'flake8' can't agree on how this should be formatted
     modin_result = modin_series.loc[
         (slice(None), 1),
     ]  # fmt: skip


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
