### PR TITLE
numpy: Add maybe reset dtypes for computational efficiency, and create string columns [no upstream]

### DIFF
--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -79,7 +79,9 @@ def fix_dtypes_and_determine_return(
     if out is not None:
         out = try_convert_from_interoperable_type(out, copy=False)
         check_can_broadcast_to_output(result, out)
-        result._query_compiler = maybe_convert_query_compiler_types(result._query_compiler, out.dtype)
+        result._query_compiler = maybe_convert_query_compiler_types(
+            result._query_compiler, out.dtype
+        )
         if isinstance(where, array):
             out._update_inplace(where.where(result, out)._query_compiler)
         elif where:
@@ -96,6 +98,7 @@ def fix_dtypes_and_determine_return(
 
         return zeros_like(result)
     return result
+
 
 def maybe_convert_query_compiler_types(query_compiler_in, new_dtype):
     cols_with_wrong_dtype = query_compiler_in.dtypes != new_dtype
@@ -201,7 +204,9 @@ class array(object):
             self._query_compiler.columns = desired_columns
         new_dtype = new_dtype if dtype is None else dtype
         if not _transposed:
-            self._query_compiler = maybe_convert_query_compiler_types(self._query_compiler, new_dtype)
+            self._query_compiler = maybe_convert_query_compiler_types(
+                self._query_compiler, new_dtype
+            )
         self.indexer = None
 
     def __getitem__(self, key):
@@ -669,7 +674,9 @@ class array(object):
             else (out.dtype if out is not None else self.dtype)
         )
         check_kwargs(order=order, casting=casting, subok=subok, where=where)
-        result = maybe_convert_query_compiler_types(self._query_compiler, out_dtype).abs()
+        result = maybe_convert_query_compiler_types(
+            self._query_compiler, out_dtype
+        ).abs()
         if dtype is not None:
             result = maybe_convert_query_compiler_types(result, dtype)
         if out is not None:
@@ -1235,7 +1242,9 @@ class array(object):
         if isinstance(where, array):
             result = self._compute_masked_variance(where, out_dtype, axis, ddof)
         else:
-            result = maybe_convert_query_compiler_types(self._query_compiler, out_dtype).var(axis=axis, skipna=False, ddof=ddof)
+            result = maybe_convert_query_compiler_types(
+                self._query_compiler, out_dtype
+            ).var(axis=axis, skipna=False, ddof=ddof)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             return result.to_numpy()[0, 0] if truthy_where else numpy.nan
@@ -1262,7 +1271,9 @@ class array(object):
         # NumPy would propagate NaN, and swap out those values in our result
         # with NaN.
         target = mask.where(self, numpy.nan)._query_compiler
-        target = maybe_convert_query_compiler_types(target, output_dtype).mean(axis=axis)
+        target = maybe_convert_query_compiler_types(target, output_dtype).mean(
+            axis=axis
+        )
         na_propagation_mask = mask.where(self, 0)._query_compiler
         na_propagation_mask = na_propagation_mask.sum(axis=axis, skipna=False)
         target = target.where(na_propagation_mask.notna(), numpy.nan)
@@ -1295,7 +1306,9 @@ class array(object):
             if isinstance(where, array):
                 result = self._compute_masked_mean(where, out_dtype, 0)
             else:
-                result = maybe_convert_query_compiler_types(self._query_compiler, out_dtype).mean(axis=0, skipna=False)
+                result = maybe_convert_query_compiler_types(
+                    self._query_compiler, out_dtype
+                ).mean(axis=0, skipna=False)
             if keepdims:
                 if out is not None and out.shape != (1,):
                     raise ValueError(
@@ -1420,13 +1433,19 @@ class array(object):
         )
         check_kwargs(order=order, subok=subok, casting=casting, where=where)
         if is_scalar(x2):
-            result = maybe_convert_query_compiler_types(self._query_compiler, out_dtype).add(x2)
+            result = maybe_convert_query_compiler_types(
+                self._query_compiler, out_dtype
+            ).add(x2)
             return fix_dtypes_and_determine_return(
                 result, self._ndim, dtype, out, where
             )
         caller, callee, new_ndim, kwargs = self._binary_op(x2)
-        caller_qc = maybe_convert_query_compiler_types(caller._query_compiler, out_dtype)
-        callee_qc = maybe_convert_query_compiler_types(callee._query_compiler, out_dtype)
+        caller_qc = maybe_convert_query_compiler_types(
+            caller._query_compiler, out_dtype
+        )
+        callee_qc = maybe_convert_query_compiler_types(
+            callee._query_compiler, out_dtype
+        )
         result = caller_qc.add(callee_qc, **kwargs)
         return fix_dtypes_and_determine_return(result, new_ndim, dtype, out, where)
 
@@ -1465,15 +1484,21 @@ class array(object):
         check_kwargs(order=order, subok=subok, casting=casting, where=where)
         if is_scalar(x2):
             return fix_dtypes_and_determine_return(
-                maybe_convert_query_compiler_types(self._query_compiler, out_dtype).truediv(x2),
+                maybe_convert_query_compiler_types(
+                    self._query_compiler, out_dtype
+                ).truediv(x2),
                 self._ndim,
                 dtype,
                 out,
                 where,
             )
         caller, callee, new_ndim, kwargs = self._binary_op(x2)
-        caller_qc = maybe_convert_query_compiler_types(caller._query_compiler, out_dtype)
-        callee_qc = maybe_convert_query_compiler_types(callee._query_compiler, out_dtype)
+        caller_qc = maybe_convert_query_compiler_types(
+            caller._query_compiler, out_dtype
+        )
+        callee_qc = maybe_convert_query_compiler_types(
+            callee._query_compiler, out_dtype
+        )
         if caller._query_compiler != self._query_compiler:
             # In this case, we are doing an operation that looks like this 1D_object/2D_object.
             # For Modin to broadcast directly, we have to swap it so that the operation is actually
@@ -1508,15 +1533,21 @@ class array(object):
         check_kwargs(order=order, subok=subok, casting=casting, where=where)
         if is_scalar(x2):
             return fix_dtypes_and_determine_return(
-                maybe_convert_query_compiler_types(self._query_compiler, out_dtype).rtruediv(x2),
+                maybe_convert_query_compiler_types(
+                    self._query_compiler, out_dtype
+                ).rtruediv(x2),
                 self._ndim,
                 dtype,
                 out,
                 where,
             )
         caller, callee, new_ndim, kwargs = self._binary_op(x2)
-        caller_qc = maybe_convert_query_compiler_types(caller._query_compiler, out_dtype)
-        callee_qc = maybe_convert_query_compiler_types(callee._query_compiler, out_dtype)
+        caller_qc = maybe_convert_query_compiler_types(
+            caller._query_compiler, out_dtype
+        )
+        callee_qc = maybe_convert_query_compiler_types(
+            callee._query_compiler, out_dtype
+        )
         if caller._query_compiler != self._query_compiler:
             result = caller_qc.truediv(callee_qc, **kwargs)
         else:
@@ -1545,7 +1576,9 @@ class array(object):
         )
         check_kwargs(order=order, subok=subok, casting=casting, where=where)
         if is_scalar(x2):
-            result = maybe_convert_query_compiler_types(self._query_compiler, out_dtype).floordiv(x2)
+            result = maybe_convert_query_compiler_types(
+                self._query_compiler, out_dtype
+            ).floordiv(x2)
             if x2 == 0 and numpy.issubdtype(out_dtype, numpy.integer):
                 # NumPy's floor_divide by 0 works differently from pandas', so we need to fix
                 # the output.
@@ -1558,8 +1591,12 @@ class array(object):
                 result, self._ndim, dtype, out, where
             )
         caller, callee, new_ndim, kwargs = self._binary_op(x2)
-        caller_qc = maybe_convert_query_compiler_types(caller._query_compiler, out_dtype)
-        callee_qc = maybe_convert_query_compiler_types(callee._query_compiler, out_dtype)
+        caller_qc = maybe_convert_query_compiler_types(
+            caller._query_compiler, out_dtype
+        )
+        callee_qc = maybe_convert_query_compiler_types(
+            callee._query_compiler, out_dtype
+        )
         if caller._query_compiler != self._query_compiler:
             # Modin does not correctly support broadcasting when the caller of the function is
             # a Series (1D), and the operand is a Dataframe (2D). We cannot workaround this using
@@ -1605,15 +1642,21 @@ class array(object):
         check_kwargs(order=order, subok=subok, casting=casting, where=where)
         if is_scalar(x2):
             return fix_dtypes_and_determine_return(
-                maybe_convert_query_compiler_types(self._query_compiler, out_dtype).pow(x2),
+                maybe_convert_query_compiler_types(self._query_compiler, out_dtype).pow(
+                    x2
+                ),
                 self._ndim,
                 dtype,
                 out,
                 where,
             )
         caller, callee, new_ndim, kwargs = self._binary_op(x2)
-        caller_qc = maybe_convert_query_compiler_types(caller._query_compiler, out_dtype)
-        callee_qc = maybe_convert_query_compiler_types(callee._query_compiler, out_dtype)
+        caller_qc = maybe_convert_query_compiler_types(
+            caller._query_compiler, out_dtype
+        )
+        callee_qc = maybe_convert_query_compiler_types(
+            callee._query_compiler, out_dtype
+        )
         if caller._query_compiler != self._query_compiler:
             # Modin does not correctly support broadcasting when the caller of the function is
             # a Series (1D), and the operand is a Dataframe (2D). We cannot workaround this using
@@ -1648,7 +1691,9 @@ class array(object):
             if axis == 1:
                 raise numpy.AxisError(1, 1)
             target = where.where(self, 1) if isinstance(where, array) else self
-            result = maybe_convert_query_compiler_types(target._query_compiler, out_dtype).prod(axis=0, skipna=False)
+            result = maybe_convert_query_compiler_types(
+                target._query_compiler, out_dtype
+            ).prod(axis=0, skipna=False)
             result = result.mul(initial)
             if keepdims:
                 if out is not None:
@@ -1706,7 +1751,9 @@ class array(object):
         if axis > 1:
             raise numpy.AxisError(axis, 2)
         target = where.where(self, 1) if isinstance(where, array) else self
-        result = maybe_convert_query_compiler_types(target._query_compiler, out_dtype).prod(axis=axis, skipna=False)
+        result = maybe_convert_query_compiler_types(
+            target._query_compiler, out_dtype
+        ).prod(axis=axis, skipna=False)
         result = result.mul(initial)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
@@ -1749,15 +1796,21 @@ class array(object):
         check_kwargs(order=order, subok=subok, casting=casting, where=where)
         if is_scalar(x2):
             return fix_dtypes_and_determine_return(
-                maybe_convert_query_compiler_types(self._query_compiler, out_dtype).mul(x2),
+                maybe_convert_query_compiler_types(self._query_compiler, out_dtype).mul(
+                    x2
+                ),
                 self._ndim,
                 dtype,
                 out,
                 where,
             )
         caller, callee, new_ndim, kwargs = self._binary_op(x2)
-        caller_qc = maybe_convert_query_compiler_types(caller._query_compiler, out_dtype)
-        callee_qc = maybe_convert_query_compiler_types(callee._query_compiler, out_dtype)
+        caller_qc = maybe_convert_query_compiler_types(
+            caller._query_compiler, out_dtype
+        )
+        callee_qc = maybe_convert_query_compiler_types(
+            callee._query_compiler, out_dtype
+        )
         result = caller_qc.mul(callee_qc, **kwargs)
         return fix_dtypes_and_determine_return(result, new_ndim, dtype, out, where)
 
@@ -1865,7 +1918,9 @@ class array(object):
         )
         check_kwargs(order=order, subok=subok, casting=casting, where=where)
         if is_scalar(x2):
-            result = maybe_convert_query_compiler_types(self._query_compiler, out_dtype).mod(x2)
+            result = maybe_convert_query_compiler_types(
+                self._query_compiler, out_dtype
+            ).mod(x2)
             if x2 == 0 and numpy.issubdtype(out_dtype, numpy.integer):
                 # NumPy's remainder by 0 works differently from pandas', so we need to fix
                 # the output.
@@ -1881,8 +1936,12 @@ class array(object):
             raise NotImplementedError(
                 "Using remainder with broadcast is not currently available in Modin."
             )
-        caller_qc = maybe_convert_query_compiler_types(caller._query_compiler, out_dtype)
-        callee_qc = maybe_convert_query_compiler_types(callee._query_compiler, out_dtype)
+        caller_qc = maybe_convert_query_compiler_types(
+            caller._query_compiler, out_dtype
+        )
+        callee_qc = maybe_convert_query_compiler_types(
+            callee._query_compiler, out_dtype
+        )
         result = caller_qc.mod(callee_qc, **kwargs)
         if callee._query_compiler.eq(0).any() and numpy.issubdtype(
             out_dtype, numpy.integer
@@ -1917,15 +1976,21 @@ class array(object):
         check_kwargs(order=order, subok=subok, casting=casting, where=where)
         if is_scalar(x2):
             return fix_dtypes_and_determine_return(
-                maybe_convert_query_compiler_types(self._query_compiler, out_dtype).sub(x2),
+                maybe_convert_query_compiler_types(self._query_compiler, out_dtype).sub(
+                    x2
+                ),
                 self._ndim,
                 dtype,
                 out,
                 where,
             )
         caller, callee, new_ndim, kwargs = self._binary_op(x2)
-        caller_qc = maybe_convert_query_compiler_types(caller._query_compiler, out_dtype)
-        callee_qc = maybe_convert_query_compiler_types(callee._query_compiler, out_dtype)
+        caller_qc = maybe_convert_query_compiler_types(
+            caller._query_compiler, out_dtype
+        )
+        callee_qc = maybe_convert_query_compiler_types(
+            callee._query_compiler, out_dtype
+        )
         if caller._query_compiler != self._query_compiler:
             # In this case, we are doing an operation that looks like this 1D_object - 2D_object.
             # For Modin to broadcast directly, we have to swap it so that the operation is actually
@@ -1960,15 +2025,21 @@ class array(object):
         check_kwargs(order=order, subok=subok, casting=casting, where=where)
         if is_scalar(x2):
             return fix_dtypes_and_determine_return(
-                maybe_convert_query_compiler_types(self._query_compiler, out_dtype).rsub(x2),
+                maybe_convert_query_compiler_types(
+                    self._query_compiler, out_dtype
+                ).rsub(x2),
                 self._ndim,
                 dtype,
                 out,
                 where,
             )
         caller, callee, new_ndim, kwargs = self._binary_op(x2)
-        caller_qc = maybe_convert_query_compiler_types(caller._query_compiler, out_dtype)
-        callee_qc = maybe_convert_query_compiler_types(callee._query_compiler, out_dtype)
+        caller_qc = maybe_convert_query_compiler_types(
+            caller._query_compiler, out_dtype
+        )
+        callee_qc = maybe_convert_query_compiler_types(
+            callee._query_compiler, out_dtype
+        )
         if caller._query_compiler != self._query_compiler:
             # In this case, we are doing an operation that looks like this 1D_object - 2D_object.
             # For Modin to broadcast directly, we have to swap it so that the operation is actually
@@ -2000,7 +2071,9 @@ class array(object):
             if axis == 1:
                 raise numpy.AxisError(1, 1)
             target = where.where(self, 0) if isinstance(where, array) else self
-            result = maybe_convert_query_compiler_types(target._query_compiler, out_dtype).sum(axis=0, skipna=False)
+            result = maybe_convert_query_compiler_types(
+                target._query_compiler, out_dtype
+            ).sum(axis=0, skipna=False)
             result = result.add(initial)
             if keepdims:
                 if out is not None:
@@ -2056,7 +2129,9 @@ class array(object):
         if axis > 1:
             raise numpy.AxisError(axis, 2)
         target = where.where(self, 0) if isinstance(where, array) else self
-        result = maybe_convert_query_compiler_types(target._query_compiler, out_dtype).sum(axis=axis, skipna=False)
+        result = maybe_convert_query_compiler_types(
+            target._query_compiler, out_dtype
+        ).sum(axis=axis, skipna=False)
         result = result.add(initial)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
@@ -2554,7 +2629,11 @@ class array(object):
     def transpose(self):
         if self._ndim == 1:
             return self
-        return array(_query_compiler=self._query_compiler.transpose(), _ndim=self._ndim, _transposed=True)
+        return array(
+            _query_compiler=self._query_compiler.transpose(),
+            _ndim=self._ndim,
+            _transposed=True,
+        )
 
     T = property(transpose)
 

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -197,7 +197,7 @@ class array(object):
         # than pair columns with the same name and multiply them.)
         self._query_compiler = self._query_compiler.reset_index(drop=True)
         desired_columns = pandas.Index(
-            [str(pos) for pos in range(len(self._query_compiler.columns))]
+            [f"_{str(pos)}" for pos in range(len(self._query_compiler.columns))]
         )
         if not self._query_compiler.columns.equals(desired_columns):
             self._query_compiler.columns = desired_columns

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -202,6 +202,8 @@ class array(object):
         if not self._query_compiler.columns.equals(desired_columns):
             self._query_compiler.columns = desired_columns
         new_dtype = new_dtype if dtype is None else dtype
+        if isinstance(new_dtype, pandas.Float64Dtype):
+            new_dtype = numpy.float64
         if not _transposed:
             self._query_compiler = maybe_convert_query_compiler_types(
                 self._query_compiler, new_dtype

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -197,7 +197,7 @@ class array(object):
         # than pair columns with the same name and multiply them.)
         self._query_compiler = self._query_compiler.reset_index(drop=True)
         desired_columns = pandas.Index(
-            [f"_{str(pos)}" for pos in range(len(self._query_compiler.columns))]
+            [f"{str(pos)}" for pos in range(len(self._query_compiler.columns))]
         )
         if not self._query_compiler.columns.equals(desired_columns):
             self._query_compiler.columns = desired_columns


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Do not upstream.
<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
