### PR TITLE
FEAT: Add partial support for groupby.idxmax/idxmin [upstream]

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -338,7 +338,10 @@ class DataFrameGroupBy(ClassLogger):
             agg_kwargs=dict(min_count=min_count),
         )
 
-    def idxmax(self, axis=0, skipna=True, numeric_only=False):
+    def idxmax(self, axis=0, skipna=True, numeric_only=True):
+        if not all(d != np.dtype("O") for d in self._df.dtypes):
+            raise TypeError("reduce operation 'argmin' not allowed for this dtype")
+
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_idxmax,
             agg_kwargs=dict(axis=axis, skipna=skipna),
@@ -472,7 +475,9 @@ class DataFrameGroupBy(ClassLogger):
 
         if isinstance(self._df, Series):
             if not is_numeric_dtype(self._df.dtypes):
-                raise TypeError(f"unsupported operand type for -: got {self._df.dtypes}")
+                raise TypeError(
+                    f"unsupported operand type for -: got {self._df.dtypes}"
+                )
         elif isinstance(self._df, DataFrame):
             for col, dtype in self._df.dtypes.items():
                 if col not in self._by.columns and not is_numeric_dtype(dtype):
@@ -672,7 +677,10 @@ class DataFrameGroupBy(ClassLogger):
     def bfill(self, limit=None):
         return self.fillna(limit=limit, method="bfill")
 
-    def idxmin(self, axis=0, skipna=True, numeric_only=False):
+    def idxmin(self, axis=0, skipna=True, numeric_only=True):
+        if not all(d != np.dtype("O") for d in self._df.dtypes):
+            raise TypeError("reduce operation 'argmin' not allowed for this dtype")
+
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_idxmin,
             agg_kwargs=dict(axis=axis, skipna=skipna),
@@ -1127,7 +1135,9 @@ class DataFrameGroupBy(ClassLogger):
 
         if isinstance(self._df, Series):
             if not is_numeric_dtype(self._df.dtypes):
-                raise TypeError(f"unsupported operand type for -: got {self._df.dtypes}")
+                raise TypeError(
+                    f"unsupported operand type for -: got {self._df.dtypes}"
+                )
         elif isinstance(self._df, DataFrame):
             for col, dtype in self._df.dtypes.items():
                 if col not in self._by.columns and not is_numeric_dtype(dtype):

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -339,7 +339,7 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def idxmax(self, axis=0, skipna=True, numeric_only=True):
-        if any(d == np.dtype("O") for d in self._df.dtypes):
+        if any(d == np.dtype("O") for d in self._df._get_dtypes()):
             raise TypeError("reduce operation 'argmin' not allowed for this dtype")
 
         return self._wrap_aggregation(
@@ -678,7 +678,7 @@ class DataFrameGroupBy(ClassLogger):
         return self.fillna(limit=limit, method="bfill")
 
     def idxmin(self, axis=0, skipna=True, numeric_only=True):
-        if any(d == np.dtype("O") for d in self._df.dtypes):
+        if any(d == np.dtype("O") for d in self._df._get_dtypes()):
             raise TypeError("reduce operation 'argmin' not allowed for this dtype")
 
         return self._wrap_aggregation(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -339,7 +339,7 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def idxmax(self, axis=0, skipna=True, numeric_only=True):
-        if not all(d != np.dtype("O") for d in self._df.dtypes):
+        if any(d == np.dtype("O") for d in self._df.dtypes):
             raise TypeError("reduce operation 'argmin' not allowed for this dtype")
 
         return self._wrap_aggregation(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -338,8 +338,12 @@ class DataFrameGroupBy(ClassLogger):
             agg_kwargs=dict(min_count=min_count),
         )
 
-    def idxmax(self):
-        return self._default_to_pandas(lambda df: df.idxmax())
+    def idxmax(self, axis=0, skipna=True, numeric_only=False):
+        return self._wrap_aggregation(
+            type(self._query_compiler).groupby_idxmax,
+            agg_kwargs=dict(axis=axis, skipna=skipna),
+            numeric_only=numeric_only,
+        )
 
     @property
     def ndim(self):
@@ -668,8 +672,12 @@ class DataFrameGroupBy(ClassLogger):
     def bfill(self, limit=None):
         return self.fillna(limit=limit, method="bfill")
 
-    def idxmin(self):
-        return self._default_to_pandas(lambda df: df.idxmin())
+    def idxmin(self, axis=0, skipna=True, numeric_only=False):
+        return self._wrap_aggregation(
+            type(self._query_compiler).groupby_idxmin,
+            agg_kwargs=dict(axis=axis, skipna=skipna),
+            numeric_only=numeric_only,
+        )
 
     def prod(self, numeric_only=None, min_count=0):
         return self._wrap_aggregation(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -678,7 +678,7 @@ class DataFrameGroupBy(ClassLogger):
         return self.fillna(limit=limit, method="bfill")
 
     def idxmin(self, axis=0, skipna=True, numeric_only=True):
-        if not all(d != np.dtype("O") for d in self._df.dtypes):
+        if any(d == np.dtype("O") for d in self._df.dtypes):
             raise TypeError("reduce operation 'argmin' not allowed for this dtype")
 
         return self._wrap_aggregation(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
