### PR TITLE
Start to support .loc[slice] (unsure whether to upstream)

### DIFF
--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -633,6 +633,25 @@ class _LocIndexer(_LocationIndexerBase):
         if self.df.empty:
             return self.df._default_to_pandas(lambda df: df.loc[key])
 
+        # Limited support for slicing operations on loc, and predominantly
+        # only with positional mapping by translating it to an iloc. To
+        # support proper labels (sorted) we will need to translate the
+        # existing index to a mask OR translate the expression to a set of
+        # predicates.
+        if is_slice(key):
+            if key.step is not None:
+                raise NotImplementedError("Slice with step not supported for loc")
+            if key.start is None and key.stop is None:
+                return self.df 
+            if key.start is None:
+                new_index = (self.df.index <= key.stop)
+                return self.df.iloc[ new_index.start : ( new_index.stop + 1) ]
+            if key.stop is None:
+                new_index = (self.df.index >= key.start)
+                return self.df.iloc[ new_index.start : ( new_index.stop + 1) ]
+            # Works for a positional mapping
+            return self.df.iloc[ key.start : ( key.stop + 1) ]
+
         if (
             isinstance(key, tuple)
             and len(key) == 2

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -644,11 +644,11 @@ class _LocIndexer(_LocationIndexerBase):
             if key.start is None and key.stop is None:
                 return self.df 
             if key.start is None:
-                new_index = (self.df.index <= key.stop)
-                return self.df.iloc[ new_index.start : ( new_index.stop + 1) ]
+                arr = (self.df.index <= key.stop)
+                return self.df.iloc[ arr ]
             if key.stop is None:
-                new_index = (self.df.index >= key.start)
-                return self.df.iloc[ new_index.start : ( new_index.stop + 1) ]
+                arr  = (self.df.index >= key.start)
+                return self.df.iloc[ arr ]
             # Works for a positional mapping
             return self.df.iloc[ key.start : ( key.stop + 1) ]
 


### PR DESCRIPTION
This helps provide limited support for using a slice in .loc calls; 
which is a pre-requisite to a lot of other interesting operations. 
This only provides support for positional indexes and it does so
by translating to iloc. The next step will be to start providing
slice support for labels properly and then work on the time index.