### PR TITLE
REFACTOR: Revert reindex change

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2269,18 +2269,10 @@ class BasePandasDataset(ClassLogger):
         """
         new_query_compiler = None
         if index is not None:
-            # TODO(REFACTOR): see how/whether to detect modin.pandas index in a better
-            # way. Right now in upsteram modin we always try to convert the index to a
-            # pandas.Index. That is not desirable for large indexes that we store in the
-            # service.
-            # Use duck typing to detect modin.pandas indexes, which are rpyc netrefs.
-            # pandas.Index and modin.pandas.Index and not much else has an attribute
-            # called "_summary".
-            if hasattr(index, "_summary"):
-                index = self._copy_index_metadata(source=self.index, destination=index)
-            new_query_compiler = self._query_compiler.reindex(
-                axis=0, labels=index, **kwargs
-            )
+            if not isinstance(index, pandas.Index) or not index.equals(self.index):
+                new_query_compiler = self._query_compiler.reindex(
+                    axis=0, labels=index, **kwargs
+                )
         if new_query_compiler is None:
             new_query_compiler = self._query_compiler
         final_query_compiler = None


### PR DESCRIPTION
This reverts commit fff7b9823a7f15967f4d1bddd2701750c2911d2c.

It turns out we don't need this commit. We'll always check for index equality, but that's okay for now.
