### PR TITLE
REFACTOR: Revert questionable performance changes

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3634,16 +3634,8 @@ class BasePandasDataset(ClassLogger):
         BasePandasDataset
             Located dataset.
         """
-        if not self._query_compiler.lazy_execution:
-            if len(self) == 0:
-                return self._default_to_pandas("__getitem__", key)
-            # fastpath for common case
-            if isinstance(key, str) and key in self._query_compiler.columns:
-                return self._getitem(key)
-            elif is_list_like(key) and all(
-                k in self._query_compiler.columns for k in key
-            ):
-                return self._getitem(key)
+        if not self._query_compiler.lazy_execution and len(self) == 0:
+            return self._default_to_pandas("__getitem__", key)
         # see if we can slice the rows
         # This lets us reuse code in pandas to error check
         indexer = None

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -312,9 +312,7 @@ class Series(BasePandasDataset):
         try:
             return object.__getattribute__(self, key)
         except AttributeError as err:
-            if not self._query_compiler.lazy_execution and (
-                key not in _ATTRS_NO_LOOKUP and key in self.index
-            ):
+            if key not in _ATTRS_NO_LOOKUP and key in self.index:
                 return self[key]
             raise err
 


### PR DESCRIPTION
revert 4c4dd74d95e1dc50f3940128e95fd39731078a9b

neither @vnlitvinov nor I can see how these help performance, and the series `__getattr__` one seems to be functionally incorrect in that it makes `getattr(series, some_index_value)` impossible.

I don't notice performance differences in manual testing; I'm checking the CI performance in the PR in the other repo.