### PR TITLE
REFACTOR: Revert "Call fast path for __getitem__ if not lazy"

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3634,16 +3634,13 @@ class BasePandasDataset(ClassLogger):
         BasePandasDataset
             Located dataset.
         """
-        if not self._query_compiler.lazy_execution:
-            if len(self) == 0:
-                return self._default_to_pandas("__getitem__", key)
-            # fastpath for common case
-            if isinstance(key, str) and key in self._query_compiler.columns:
-                return self._getitem(key)
-            elif is_list_like(key) and all(
-                k in self._query_compiler.columns for k in key
-            ):
-                return self._getitem(key)
+        if not self._query_compiler.lazy_execution and len(self) == 0:
+            return self._default_to_pandas("__getitem__", key)
+        # fastpath for common case
+        if isinstance(key, str) and key in self._query_compiler.columns:
+            return self._getitem(key)
+        elif is_list_like(key) and all(k in self._query_compiler.columns for k in key):
+            return self._getitem(key)
         # see if we can slice the rows
         # This lets us reuse code in pandas to error check
         indexer = None


### PR DESCRIPTION
This reverts commit f90e518c673ac57c5b1e2a3277564909beb10d96.

Neither @mvashishtha nor @vnlitvinov see how this helps performance. `lazy_execution` is on for the ponder backend and modin-omnisci has already added the lazy execution check here: https://github.com/modin-project/modin/commit/39afc07455dd0dad1807cdb1b8b1d18c4c3d8775
